### PR TITLE
Synchronising fork with master, condensing output strings for nlp

### DIFF
--- a/src/nlp/i18n.ts
+++ b/src/nlp/i18n.ts
@@ -58,7 +58,6 @@ const ENGLISH: Language = {
     for: /^for/i,
     'time(s)': /^times?/i,
     until: /^(un)?til/i,
-    forever: /^forever/i,
     monday: /^mo(n(day)?)?/i,
     tuesday: /^tu(e(s(day)?)?)?/i,
     wednesday: /^we(d(n(esday)?)?)?/i,
@@ -79,8 +78,8 @@ const ENGLISH: Language = {
     november: /^nov(ember)?/i,
     december: /^dec(ember)?/i,
     comma: /^(,\s*|(and|or)\s*)+/i,
-    Repeats: /^Repeats/i
-  }
+    Repeats: /^Repeats/i,
+  },
 }
 
 export default ENGLISH

--- a/src/nlp/index.ts
+++ b/src/nlp/index.ts
@@ -1,4 +1,4 @@
-import ToText, { DateFormatter, GetText } from './totext'
+import ToText, { DateFormatter, GetText, ToStringOptions } from './totext'
 import parseText from './parsetext'
 import { RRule } from '../rrule'
 import { Frequency } from '../types'
@@ -124,9 +124,12 @@ const toText = function (
   rrule: RRule,
   gettext?: GetText,
   language?: Language,
-  dateFormatter?: DateFormatter
+  dateFormatter?: DateFormatter,
+  toStringOptions?: ToStringOptions
 ) {
-  return new ToText(rrule, gettext, language, dateFormatter).toString()
+  return new ToText(rrule, gettext, language, dateFormatter).toString(
+    toStringOptions
+  )
 }
 
 const { isFullyConvertible } = ToText

--- a/src/nlp/totext.ts
+++ b/src/nlp/totext.ts
@@ -195,9 +195,6 @@ export default class ToText {
         .add(
           this.plural(this.options.count) ? gettext('times') : gettext('time')
         )
-    } else {
-      this.text.push(',')
-      this.add(gettext('forever'))
     }
 
     // if (!this.isFullyConvertible()) this.add(gettext('(~ approximate)'))

--- a/src/rrule.ts
+++ b/src/rrule.ts
@@ -4,7 +4,7 @@ import IterResult, { IterArgs } from './iterresult'
 import CallbackIterResult from './callbackiterresult'
 import { Language } from './nlp/i18n'
 import { fromText, parseText, toText, isFullyConvertible } from './nlp/index'
-import { DateFormatter, GetText } from './nlp/totext'
+import { DateFormatter, GetText, ToStringOptions } from './nlp/totext'
 import {
   ParsedOptions,
   Options,
@@ -262,9 +262,10 @@ export class RRule implements QueryMethods {
   toText(
     gettext?: GetText,
     language?: Language,
-    dateFormatter?: DateFormatter
+    dateFormatter?: DateFormatter,
+    toStringOptions?: ToStringOptions
   ) {
-    return toText(this, gettext, language, dateFormatter)
+    return toText(this, gettext, language, dateFormatter, toStringOptions)
   }
 
   isFullyConvertibleToText() {

--- a/test/nlp.test.ts
+++ b/test/nlp.test.ts
@@ -25,7 +25,6 @@ const texts = [
   ['Every month on the 3rd last Tuesday', 'RRULE:FREQ=MONTHLY;BYDAY=-3TU'],
   ['Every month on the last Monday', 'RRULE:FREQ=MONTHLY;BYDAY=-1MO'],
   ['Every month on the 2nd last Friday', 'RRULE:FREQ=MONTHLY;BYDAY=-2FR'],
-  // ['Every week until January 1, 2007', 'RRULE:FREQ=WEEKLY;UNTIL=20070101T080000Z'],
   ['Every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20'],
 ]
 
@@ -43,7 +42,7 @@ describe('NLP', () => {
       const text = item[0]
       const str = item[1]
       expect(RRule.fromString(str).toText().toLowerCase()).equals(
-        text.toLowerCase(),
+        `repeats ${text.toLowerCase()}`,
         str + ' => ' + text
       )
     })
@@ -53,6 +52,8 @@ describe('NLP', () => {
     texts.forEach(function (item) {
       const text = item[0]
       const str = item[1]
+      const output = optionsToString(RRule.parseText(text))
+      console.log(text, output)
       expect(optionsToString(RRule.parseText(text))).equals(
         str,
         text + ' => ' + str
@@ -66,14 +67,16 @@ describe('NLP', () => {
       byweekday: 0,
     })
 
-    expect(rrule.toText()).to.equal('every week on Monday')
+    expect(rrule.toText()).to.equal('Repeats every week on Monday')
     expect(rrule.toString()).to.equal('RRULE:FREQ=WEEKLY;BYDAY=MO')
   })
 
   it('sorts monthdays correctly (#101)', () => {
     const options = { freq: 2, bymonthday: [3, 10, 17, 24] }
     const rule = new RRule(options)
-    expect(rule.toText()).to.equal('every week on the 3rd, 10th, 17th and 24th')
+    expect(rule.toText()).to.equal(
+      'Repeats every week on the 3rd, 10th, 17th and 24th'
+    )
   })
 
   it('shows correct text for every day', () => {
@@ -90,19 +93,19 @@ describe('NLP', () => {
       ],
     }
     const rule = new RRule(options)
-    expect(rule.toText()).to.equal('every day')
+    expect(rule.toText()).to.equal('Repeats every day')
   })
 
   it('shows correct text for every minute', () => {
     const options = { freq: RRule.MINUTELY }
     const rule = new RRule(options)
-    expect(rule.toText()).to.equal('every minute')
+    expect(rule.toText()).to.equal('Repeats every minute')
   })
 
   it('shows correct text for every (plural) minutes', () => {
     const options = { freq: RRule.MINUTELY, interval: 2 }
     const rule = new RRule(options)
-    expect(rule.toText()).to.equal('every 2 minutes')
+    expect(rule.toText()).to.equal('Repeats every 2 minutes')
   })
 
   it("by default formats 'until' correctly", () => {
@@ -111,7 +114,9 @@ describe('NLP', () => {
       until: datetime(2012, 11, 10),
     })
 
-    expect(rrule.toText()).to.equal('every week until November 10, 2012')
+    expect(rrule.toText()).to.equal(
+      'Repeats every week until November 10, 2012'
+    )
   })
 
   it("formats 'until' as desired if asked", () => {
@@ -124,7 +129,7 @@ describe('NLP', () => {
       `${day}. ${month}, ${year}`
 
     expect(rrule.toText(undefined, undefined, dateFormatter)).to.equal(
-      'every week until 10. November, 2012'
+      'Repeats every week until 10. November, 2012'
     )
   })
 })

--- a/test/nlp.test.ts
+++ b/test/nlp.test.ts
@@ -5,58 +5,90 @@ import { DateFormatter } from '../src/nlp/totext'
 import { datetime } from './lib/utils'
 
 const texts = [
-  ['Every day', 'RRULE:FREQ=DAILY'],
-  ['Every day at 10, 12 and 17', 'RRULE:FREQ=DAILY;BYHOUR=10,12,17'],
-  ['Every week', 'RRULE:FREQ=WEEKLY'],
-  ['Every hour', 'RRULE:FREQ=HOURLY'],
-  ['Every 4 hours', 'RRULE:INTERVAL=4;FREQ=HOURLY'],
-  ['Every week on Tuesday', 'RRULE:FREQ=WEEKLY;BYDAY=TU'],
-  ['Every week on Monday, Wednesday', 'RRULE:FREQ=WEEKLY;BYDAY=MO,WE'],
-  ['Every weekday', 'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR'],
-  ['Every 2 weeks', 'RRULE:INTERVAL=2;FREQ=WEEKLY'],
-  ['Every month', 'RRULE:FREQ=MONTHLY'],
-  ['Every 6 months', 'RRULE:INTERVAL=6;FREQ=MONTHLY'],
-  ['Every year', 'RRULE:FREQ=YEARLY'],
-  ['Every year on the 1st Friday', 'RRULE:FREQ=YEARLY;BYDAY=+1FR'],
-  ['Every year on the 13th Friday', 'RRULE:FREQ=YEARLY;BYDAY=+13FR'],
-  ['Every month on the 4th', 'RRULE:FREQ=MONTHLY;BYMONTHDAY=4'],
-  ['Every month on the 4th last', 'RRULE:FREQ=MONTHLY;BYMONTHDAY=-4'],
-  ['Every month on the 3rd Tuesday', 'RRULE:FREQ=MONTHLY;BYDAY=+3TU'],
-  ['Every month on the 3rd last Tuesday', 'RRULE:FREQ=MONTHLY;BYDAY=-3TU'],
-  ['Every month on the last Monday', 'RRULE:FREQ=MONTHLY;BYDAY=-1MO'],
-  ['Every month on the 2nd last Friday', 'RRULE:FREQ=MONTHLY;BYDAY=-2FR'],
-  ['Every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20'],
+  ['Every day', 'daily', 'RRULE:FREQ=DAILY'],
+  ['Every day at 10, 12 and 17', 'daily', 'RRULE:FREQ=DAILY;BYHOUR=10,12,17'],
+  ['Every week', 'weekly', 'RRULE:FREQ=WEEKLY'],
+  ['Every 2 weeks', '', 'RRULE:INTERVAL=2;FREQ=WEEKLY'],
+  ['Every hour', 'hourly', 'RRULE:FREQ=HOURLY'],
+  ['Every 4 hours', '', 'RRULE:INTERVAL=4;FREQ=HOURLY'],
+  ['Every week on Tuesday', 'weekly', 'RRULE:FREQ=WEEKLY;BYDAY=TU'],
+  ['Every week on Monday, Wednesday', '', 'RRULE:FREQ=WEEKLY;BYDAY=MO,WE'],
+  ['Every weekday', '', 'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR'],
+  ['Every 2 weeks', '', 'RRULE:INTERVAL=2;FREQ=WEEKLY'],
+  ['Every month', 'monthly', 'RRULE:FREQ=MONTHLY'],
+  ['Every 6 months', '', 'RRULE:INTERVAL=6;FREQ=MONTHLY'],
+  ['Every year', 'yearly', 'RRULE:FREQ=YEARLY'],
+  ['Every year on the 1st Friday', 'yearly', 'RRULE:FREQ=YEARLY;BYDAY=+1FR'],
+  ['Every year on the 13th Friday', 'yearly', 'RRULE:FREQ=YEARLY;BYDAY=+13FR'],
+  ['Every month on the 4th', 'monthly', 'RRULE:FREQ=MONTHLY;BYMONTHDAY=4'],
+  [
+    'Every month on the 4th last',
+    'monthly',
+    'RRULE:FREQ=MONTHLY;BYMONTHDAY=-4',
+  ],
+  [
+    'Every month on the 3rd Tuesday',
+    'monthly',
+    'RRULE:FREQ=MONTHLY;BYDAY=+3TU',
+  ],
+  [
+    'Every month on the 3rd last Tuesday',
+    'monthly',
+    'RRULE:FREQ=MONTHLY;BYDAY=-3TU',
+  ],
+  [
+    'Every month on the last Monday',
+    'monthly',
+    'RRULE:FREQ=MONTHLY;BYDAY=-1MO',
+  ],
+  [
+    'Every month on the 2nd last Friday',
+    'monthly',
+    'RRULE:FREQ=MONTHLY;BYDAY=-2FR',
+  ],
+  ['Every week for 20 times', 'weekly', 'RRULE:FREQ=WEEKLY;COUNT=20'],
 ]
 
 describe('NLP', () => {
   it('fromText()', function () {
     texts.forEach(function (item) {
-      const text = item[0]
-      const str = item[1]
-      expect(RRule.fromText(text).toString()).equals(str, text + ' => ' + str)
+      const parse = item[0]
+      const rule = item[2]
+      expect(RRule.fromText(parse).toString()).equals(
+        rule,
+        parse + ' => ' + rule
+      )
     })
   })
 
-  it('toText()', function () {
+  it('toText(options)', function () {
     texts.forEach(function (item) {
-      const text = item[0]
-      const str = item[1]
-      expect(RRule.fromString(str).toText().toLowerCase()).equals(
-        `repeats ${text.toLowerCase()}`,
-        str + ' => ' + text
+      const parse = item[0]
+      const condensed = item[1]
+      const rule = item[2]
+      expect(RRule.fromString(rule).toText().toLowerCase()).equals(
+        `repeats ${parse.toLowerCase()}`,
+        rule + ' => ' + parse
       )
+
+      const condensedToCompare = condensed
+        ? `repeats ${condensed.toLowerCase()}`
+        : 'repeats'
+      expect(
+        RRule.fromString(rule)
+          .toText(undefined, undefined, undefined, { condenseOutput: true })
+          .toLowerCase()
+      ).equals(condensedToCompare, rule + ' => ' + condensed)
     })
   })
 
   it('parseText()', function () {
     texts.forEach(function (item) {
-      const text = item[0]
-      const str = item[1]
-      const output = optionsToString(RRule.parseText(text))
-      console.log(text, output)
-      expect(optionsToString(RRule.parseText(text))).equals(
-        str,
-        text + ' => ' + str
+      const parse = item[0]
+      const rule = item[2]
+      expect(optionsToString(RRule.parseText(parse))).equals(
+        rule,
+        parse + ' => ' + rule
       )
     })
   })
@@ -68,6 +100,9 @@ describe('NLP', () => {
     })
 
     expect(rrule.toText()).to.equal('Repeats every week on Monday')
+    expect(
+      rrule.toText(undefined, undefined, undefined, { condenseOutput: true })
+    ).to.equal('Repeats weekly')
     expect(rrule.toString()).to.equal('RRULE:FREQ=WEEKLY;BYDAY=MO')
   })
 
@@ -77,6 +112,9 @@ describe('NLP', () => {
     expect(rule.toText()).to.equal(
       'Repeats every week on the 3rd, 10th, 17th and 24th'
     )
+    expect(
+      rule.toText(undefined, undefined, undefined, { condenseOutput: true })
+    ).to.equal('Repeats')
   })
 
   it('shows correct text for every day', () => {
@@ -94,6 +132,9 @@ describe('NLP', () => {
     }
     const rule = new RRule(options)
     expect(rule.toText()).to.equal('Repeats every day')
+    expect(
+      rule.toText(undefined, undefined, undefined, { condenseOutput: true })
+    ).to.equal('Repeats daily')
   })
 
   it('shows correct text for every minute', () => {
@@ -106,6 +147,9 @@ describe('NLP', () => {
     const options = { freq: RRule.MINUTELY, interval: 2 }
     const rule = new RRule(options)
     expect(rule.toText()).to.equal('Repeats every 2 minutes')
+    expect(
+      rule.toText(undefined, undefined, undefined, { condenseOutput: true })
+    ).to.equal('Repeats every 2 minutes')
   })
 
   it("by default formats 'until' correctly", () => {
@@ -117,6 +161,9 @@ describe('NLP', () => {
     expect(rrule.toText()).to.equal(
       'Repeats every week until November 10, 2012'
     )
+    expect(
+      rrule.toText(undefined, undefined, undefined, { condenseOutput: true })
+    ).to.equal('Repeats weekly')
   })
 
   it("formats 'until' as desired if asked", () => {

--- a/test/rrule.test.ts
+++ b/test/rrule.test.ts
@@ -2,6 +2,7 @@ import { parse, datetime, testRecurring, expectedDate } from './lib/utils'
 import { expect } from 'chai'
 import { RRule, rrulestr, Frequency } from '../src/index'
 import { set as setMockDate, reset as resetMockDate } from 'mockdate'
+import { optionsToString } from '../src/optionstostring'
 
 describe('RRule', function () {
   // Enable additional toString() / fromString() tests
@@ -40,7 +41,7 @@ describe('RRule', function () {
     ['Every month on the last Monday', 'RRULE:FREQ=MONTHLY;BYDAY=-1MO'],
     ['Every month on the 2nd last Friday', 'RRULE:FREQ=MONTHLY;BYDAY=-2FR'],
     // ['Every week until January 1, 2007', 'RRULE:FREQ=WEEKLY;UNTIL=20070101T080000Z'],
-    ['Every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20']
+    ['Every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20'],
   ]
 
   it('fromText()', function () {
@@ -55,40 +56,72 @@ describe('RRule', function () {
     fromTexts.forEach(function (item) {
       const text = item[0]
       const str = item[1]
-      expect(optionsToString(RRule.parseText(text))).equals(str, text + ' => ' + str)
+      expect(optionsToString(RRule.parseText(text))).equals(
+        str,
+        text + ' => ' + str
+      )
     })
   })
 
   const toTexts = [
     ['Repeats every day, forever', 'RRULE:FREQ=DAILY'],
-    ['Repeats every day at 10, 12 and 17, forever', 'RRULE:FREQ=DAILY;BYHOUR=10,12,17'],
+    [
+      'Repeats every day at 10, 12 and 17, forever',
+      'RRULE:FREQ=DAILY;BYHOUR=10,12,17',
+    ],
     ['Repeats every week, forever', 'RRULE:FREQ=WEEKLY'],
     ['Repeats every hour, forever', 'RRULE:FREQ=HOURLY'],
     ['Repeats every 4 hours, forever', 'RRULE:INTERVAL=4;FREQ=HOURLY'],
     ['Repeats every week on Tuesday, forever', 'RRULE:FREQ=WEEKLY;BYDAY=TU'],
-    ['Repeats every week on Monday, Wednesday, forever', 'RRULE:FREQ=WEEKLY;BYDAY=MO,WE'],
-    ['Repeats every weekday, forever', 'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR'],
+    [
+      'Repeats every week on Monday, Wednesday, forever',
+      'RRULE:FREQ=WEEKLY;BYDAY=MO,WE',
+    ],
+    [
+      'Repeats every weekday, forever',
+      'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR',
+    ],
     ['Repeats every weekend, forever', 'RRULE:FREQ=WEEKLY;BYDAY=SA,SU'],
     ['Repeats every 2 weeks, forever', 'RRULE:INTERVAL=2;FREQ=WEEKLY'],
     ['Repeats every month, forever', 'RRULE:FREQ=MONTHLY'],
     ['Repeats every 6 months, forever', 'RRULE:INTERVAL=6;FREQ=MONTHLY'],
     ['Repeats every year, forever', 'RRULE:FREQ=YEARLY'],
-    ['Repeats every month on the 4th, forever', 'RRULE:FREQ=MONTHLY;BYMONTHDAY=4'],
-    ['Repeats every month on the 4th last, forever', 'RRULE:FREQ=MONTHLY;BYMONTHDAY=-4'],
-    ['Repeats every month on the 3rd Tuesday, forever', 'RRULE:FREQ=MONTHLY;BYDAY=+3TU'],
-    ['Repeats every month on the 3rd last Tuesday, forever', 'RRULE:FREQ=MONTHLY;BYDAY=-3TU'],
-    ['Repeats every month on the last Monday, forever', 'RRULE:FREQ=MONTHLY;BYDAY=-1MO'],
-    ['Repeats every month on the 2nd last Friday, forever', 'RRULE:FREQ=MONTHLY;BYDAY=-2FR'],
+    [
+      'Repeats every month on the 4th, forever',
+      'RRULE:FREQ=MONTHLY;BYMONTHDAY=4',
+    ],
+    [
+      'Repeats every month on the 4th last, forever',
+      'RRULE:FREQ=MONTHLY;BYMONTHDAY=-4',
+    ],
+    [
+      'Repeats every month on the 3rd Tuesday, forever',
+      'RRULE:FREQ=MONTHLY;BYDAY=+3TU',
+    ],
+    [
+      'Repeats every month on the 3rd last Tuesday, forever',
+      'RRULE:FREQ=MONTHLY;BYDAY=-3TU',
+    ],
+    [
+      'Repeats every month on the last Monday, forever',
+      'RRULE:FREQ=MONTHLY;BYDAY=-1MO',
+    ],
+    [
+      'Repeats every month on the 2nd last Friday, forever',
+      'RRULE:FREQ=MONTHLY;BYDAY=-2FR',
+    ],
     // ['Every week until January 1, 2007, forever', 'RRULE:FREQ=WEEKLY;UNTIL=20070101T080000Z'],
-    ['Repeats every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20']
+    ['Repeats every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20'],
   ]
 
   it('toText()', function () {
     toTexts.forEach(function (item) {
       const text = item[0]
       const str = item[1]
-      expect(RRule.fromString(str).toText().toLowerCase()).equals(text.toLowerCase(),
-        str + ' => ' + text)
+      expect(RRule.fromString(str).toText().toLowerCase()).equals(
+        text.toLowerCase(),
+        str + ' => ' + text
+      )
     })
   })
 
@@ -4211,16 +4244,13 @@ describe('RRule', function () {
 
     expect(ruleString).to.equal('DTSTART:09900101T000000Z\nRRULE:COUNT=1')
     expect(rrule2.count()).to.equal(1)
-<<<<<<< HEAD
-    expect(rrule2.all()).to.deep.equal([
-      new Date(Date.UTC(990, 0, 1, 0, 0, 0))
-    ])
+    expect(rrule2.all()).to.deep.equal([new Date(Date.UTC(990, 0, 1, 0, 0, 0))])
   })
 
   it('permits integers in byweekday (#153)', () => {
     const rrule = new RRule({
       freq: RRule.WEEKLY,
-      byweekday: 0
+      byweekday: 0,
     })
 
     expect(rrule.toText()).to.equal('Repeats every week on Monday, forever')
@@ -4228,34 +4258,37 @@ describe('RRule', function () {
   })
 
   it('sorts monthdays correctly (#101)', () => {
-    const options = { "freq": 2, "bymonthday": [3, 10, 17, 24] }
+    const options = { freq: 2, bymonthday: [3, 10, 17, 24] }
     const rule = new RRule(options)
-    expect(rule.toText()).to.equal('Repeats every week on the 3rd, 10th, 17th and 24th, forever')
+    expect(rule.toText()).to.equal(
+      'Repeats every week on the 3rd, 10th, 17th and 24th, forever'
+    )
   })
 
   it('shows correct text for every day', () => {
-    const options = { "freq": RRule.WEEKLY, byweekday: [
-      RRule.MO, RRule.TU, RRule.WE, RRule.TH, RRule.FR, RRule.SA, RRule.SU
-    ]}
+    const options = {
+      freq: RRule.WEEKLY,
+      byweekday: [
+        RRule.MO,
+        RRule.TU,
+        RRule.WE,
+        RRule.TH,
+        RRule.FR,
+        RRule.SA,
+        RRule.SU,
+      ],
+    }
     const rule = new RRule(options)
     expect(rule.toText()).to.equal('Repeats every day, forever')
   })
 
   it('shows correct text for weekends', () => {
-    const options = { "freq": RRule.WEEKLY, byweekday: [
-      RRule.SA, RRule.SU
-    ]}
+    const options = { freq: RRule.WEEKLY, byweekday: [RRule.SA, RRule.SU] }
     const rule = new RRule(options)
     expect(rule.toText()).to.equal('Repeats every weekend, forever')
   })
 
-  describe('time zones', () => {
-=======
-    expect(rrule2.all()).to.deep.equal([datetime(990, 1, 1, 0, 0, 0)])
-  })
-
   describe('time zones, when recurrence is in dst', () => {
->>>>>>> 8d32705712f731124a0e1b516d73259e8eac5b20
     const targetZone = 'America/Los_Angeles'
     const startDate = datetime(2013, 8, 6, 11, 0, 0)
     const dtstart = startDate
@@ -4272,14 +4305,7 @@ describe('RRule', function () {
       const recurrence = rule.all()[0]
       const expected = expectedDate(startDate, currentLocalDate, targetZone)
 
-<<<<<<< HEAD
-      expect(recurrence)
-        .to.deep.equal(
-          expected
-        )
-=======
       expect(recurrence).to.deep.equal(expected)
->>>>>>> 8d32705712f731124a0e1b516d73259e8eac5b20
 
       resetMockDate()
     })
@@ -4296,14 +4322,7 @@ describe('RRule', function () {
       const recurrence = rule.all()[0]
       const expected = expectedDate(startDate, currentLocalDate, targetZone)
 
-<<<<<<< HEAD
-      expect(recurrence)
-        .to.deep.equal(
-          expected
-        )
-=======
       expect(recurrence).to.deep.equal(expected)
->>>>>>> 8d32705712f731124a0e1b516d73259e8eac5b20
 
       resetMockDate()
     })
@@ -4320,14 +4339,7 @@ describe('RRule', function () {
       const recurrence = rule.after(new Date(0))
       const expected = expectedDate(startDate, currentLocalDate, targetZone)
 
-<<<<<<< HEAD
-      expect(recurrence)
-        .to.deep.equal(
-          expected
-        )
-=======
       expect(recurrence).to.deep.equal(expected)
->>>>>>> 8d32705712f731124a0e1b516d73259e8eac5b20
 
       resetMockDate()
     })

--- a/test/rrule.test.ts
+++ b/test/rrule.test.ts
@@ -64,53 +64,35 @@ describe('RRule', function () {
   })
 
   const toTexts = [
-    ['Repeats every day, forever', 'RRULE:FREQ=DAILY'],
+    ['Repeats every day', 'RRULE:FREQ=DAILY'],
+    ['Repeats every day at 10, 12 and 17', 'RRULE:FREQ=DAILY;BYHOUR=10,12,17'],
+    ['Repeats every week', 'RRULE:FREQ=WEEKLY'],
+    ['Repeats every hour', 'RRULE:FREQ=HOURLY'],
+    ['Repeats every 4 hours', 'RRULE:INTERVAL=4;FREQ=HOURLY'],
+    ['Repeats every week on Tuesday', 'RRULE:FREQ=WEEKLY;BYDAY=TU'],
     [
-      'Repeats every day at 10, 12 and 17, forever',
-      'RRULE:FREQ=DAILY;BYHOUR=10,12,17',
-    ],
-    ['Repeats every week, forever', 'RRULE:FREQ=WEEKLY'],
-    ['Repeats every hour, forever', 'RRULE:FREQ=HOURLY'],
-    ['Repeats every 4 hours, forever', 'RRULE:INTERVAL=4;FREQ=HOURLY'],
-    ['Repeats every week on Tuesday, forever', 'RRULE:FREQ=WEEKLY;BYDAY=TU'],
-    [
-      'Repeats every week on Monday, Wednesday, forever',
+      'Repeats every week on Monday, Wednesday',
       'RRULE:FREQ=WEEKLY;BYDAY=MO,WE',
     ],
+    ['Repeats every weekday', 'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR'],
+    ['Repeats every weekend', 'RRULE:FREQ=WEEKLY;BYDAY=SA,SU'],
+    ['Repeats every 2 weeks', 'RRULE:INTERVAL=2;FREQ=WEEKLY'],
+    ['Repeats every month', 'RRULE:FREQ=MONTHLY'],
+    ['Repeats every 6 months', 'RRULE:INTERVAL=6;FREQ=MONTHLY'],
+    ['Repeats every year', 'RRULE:FREQ=YEARLY'],
+    ['Repeats every month on the 4th', 'RRULE:FREQ=MONTHLY;BYMONTHDAY=4'],
+    ['Repeats every month on the 4th last', 'RRULE:FREQ=MONTHLY;BYMONTHDAY=-4'],
+    ['Repeats every month on the 3rd Tuesday', 'RRULE:FREQ=MONTHLY;BYDAY=+3TU'],
     [
-      'Repeats every weekday, forever',
-      'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR',
-    ],
-    ['Repeats every weekend, forever', 'RRULE:FREQ=WEEKLY;BYDAY=SA,SU'],
-    ['Repeats every 2 weeks, forever', 'RRULE:INTERVAL=2;FREQ=WEEKLY'],
-    ['Repeats every month, forever', 'RRULE:FREQ=MONTHLY'],
-    ['Repeats every 6 months, forever', 'RRULE:INTERVAL=6;FREQ=MONTHLY'],
-    ['Repeats every year, forever', 'RRULE:FREQ=YEARLY'],
-    [
-      'Repeats every month on the 4th, forever',
-      'RRULE:FREQ=MONTHLY;BYMONTHDAY=4',
-    ],
-    [
-      'Repeats every month on the 4th last, forever',
-      'RRULE:FREQ=MONTHLY;BYMONTHDAY=-4',
-    ],
-    [
-      'Repeats every month on the 3rd Tuesday, forever',
-      'RRULE:FREQ=MONTHLY;BYDAY=+3TU',
-    ],
-    [
-      'Repeats every month on the 3rd last Tuesday, forever',
+      'Repeats every month on the 3rd last Tuesday',
       'RRULE:FREQ=MONTHLY;BYDAY=-3TU',
     ],
+    ['Repeats every month on the last Monday', 'RRULE:FREQ=MONTHLY;BYDAY=-1MO'],
     [
-      'Repeats every month on the last Monday, forever',
-      'RRULE:FREQ=MONTHLY;BYDAY=-1MO',
-    ],
-    [
-      'Repeats every month on the 2nd last Friday, forever',
+      'Repeats every month on the 2nd last Friday',
       'RRULE:FREQ=MONTHLY;BYDAY=-2FR',
     ],
-    // ['Every week until January 1, 2007, forever', 'RRULE:FREQ=WEEKLY;UNTIL=20070101T080000Z'],
+    // ['Every week until January 1, 2007', 'RRULE:FREQ=WEEKLY;UNTIL=20070101T080000Z'],
     ['Repeats every week for 20 times', 'RRULE:FREQ=WEEKLY;COUNT=20'],
   ]
 
@@ -4253,7 +4235,7 @@ describe('RRule', function () {
       byweekday: 0,
     })
 
-    expect(rrule.toText()).to.equal('Repeats every week on Monday, forever')
+    expect(rrule.toText()).to.equal('Repeats every week on Monday')
     expect(rrule.toString()).to.equal('RRULE:FREQ=WEEKLY;BYDAY=MO')
   })
 
@@ -4261,7 +4243,7 @@ describe('RRule', function () {
     const options = { freq: 2, bymonthday: [3, 10, 17, 24] }
     const rule = new RRule(options)
     expect(rule.toText()).to.equal(
-      'Repeats every week on the 3rd, 10th, 17th and 24th, forever'
+      'Repeats every week on the 3rd, 10th, 17th and 24th'
     )
   })
 
@@ -4279,13 +4261,13 @@ describe('RRule', function () {
       ],
     }
     const rule = new RRule(options)
-    expect(rule.toText()).to.equal('Repeats every day, forever')
+    expect(rule.toText()).to.equal('Repeats every day')
   })
 
   it('shows correct text for weekends', () => {
     const options = { freq: RRule.WEEKLY, byweekday: [RRule.SA, RRule.SU] }
     const rule = new RRule(options)
-    expect(rule.toText()).to.equal('Repeats every weekend, forever')
+    expect(rule.toText()).to.equal('Repeats every weekend')
   })
 
   describe('time zones, when recurrence is in dst', () => {


### PR DESCRIPTION
- [x] Show short repeats - I've done this using a new options object to encapsulate the changes, so this just effects the `toText()` function, leaving original/existing functionality intact
  - [x] `REPEATS HOURLY`
  - [x] `REPEATS DAILY`
  - [x] `REPEATS WEEKLY`
  - [x] `REPEATS MONTHLY`
  - [x] `REPEATS YEARLY`
- [x] Condense longer strings down to just `REPEATS`